### PR TITLE
enable link time optimization to reduce binary size

### DIFF
--- a/bookinfo/reviews/Cargo.toml
+++ b/bookinfo/reviews/Cargo.toml
@@ -22,3 +22,6 @@ serde_json = "1.0.94"
 spin-sdk = { git = "https://github.com/fermyon/spin" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+
+[profile.release]
+lto = true


### PR DESCRIPTION
reduces the wasm module size from 3M to 1.3M